### PR TITLE
fix: reorder parameters filter priority and remove bad logic assignment

### DIFF
--- a/src/utils/LocalDbUtils.ts
+++ b/src/utils/LocalDbUtils.ts
@@ -11,7 +11,7 @@ function filterObjects(idbCursorRequest: IDBRequest,
 					   resolve: (value: (ApiData[] | PromiseLike<ApiData[]>)) => void,
 					   results: ApiData[],
 					   params?: DataRequestParams
-) {
+): void {
 	const cursor = idbCursorRequest.result
 
 	if (!cursor) {
@@ -29,19 +29,17 @@ function filterObjects(idbCursorRequest: IDBRequest,
 		return
 	}
 
+	if (params.pageSize && results.length === params.pageSize) {
+		resolve(results)
+
+		return
+	}
+
 	if (params.search) {
 		const concatenatedValues = `${value.id}${value.slug}${value.name}`.toLowerCase()
 		if (concatenatedValues.includes(params.search.toLowerCase())) {
 			results.push(value)
 		}
-	}
-	
-	if (params.pageSize && results.length === params.pageSize) {
-		resolve(results)
-		
-		return
-	} else {
-		results.push(value)
 	}
 
 	cursor.continue()


### PR DESCRIPTION
This pull request includes changes to the `filterObjects` function in `src/utils/LocalDbUtils.ts` to improve code readability and maintainability. The most important changes involve restructuring the function to ensure consistent handling of search parameters and resolving results.

Code readability and maintainability improvements:

* [`src/utils/LocalDbUtils.ts`](diffhunk://#diff-10dcbc5d2ee67593d73199334c5706d1db484cbf15ecdcf22e9f871581a115a9L14-R14): Modified the `filterObjects` function signature to explicitly state that it returns `void`.
* [`src/utils/LocalDbUtils.ts`](diffhunk://#diff-10dcbc5d2ee67593d73199334c5706d1db484cbf15ecdcf22e9f871581a115a9L32-R43): Reorganized the logic to check for `params.search` after resolving results based on `params.pageSize`, ensuring consistent handling and improving readability.

## Fixes
* [`src/utils/LocalDbUtils.ts`](diffhunk://#diff-10dcbc5d2ee67593d73199334c5706d1db484cbf15ecdcf22e9f871581a115a9L32-R43): Adjust the order for filtering objects for avoiding the addition of duplicates in the search results
