### PR TITLE
fix: set publishers property as a nullish value

### DIFF
--- a/src/data/types/Game.ts
+++ b/src/data/types/Game.ts
@@ -19,7 +19,7 @@ export type Game = GameCommons & {
 	additionsCount: number
 	gameSeriesCount: number
 	developers: Developer[]
-	publishers: Publisher[]
+	publishers?: Publisher[]
 	descriptionRaw: string
 	shortScreenshots?: ImageCommons[]
 	screenshots?: Screenshots

--- a/src/filters/LocalDbFilter.ts
+++ b/src/filters/LocalDbFilter.ts
@@ -48,45 +48,45 @@ export class LocalDbFilter implements ILocalDbFilter {
 
 			if (params.developers) {
 				matches = matches && data.developers.some(dev =>
-															  params.developers!.includes(
+															  params.developers?.includes(
 																  String(dev.id))
-															  || params.developers!.includes(
+															  || params.developers?.includes(
 																  dev.slug)
 				)
 			}
 
-			if (params.publishers) {
+			if (params.publishers && data.publishers) {
 				matches = matches && data.publishers.some(pub =>
-															  params.publishers!.includes(
+															  params.publishers?.includes(
 																  String(pub.id))
-															  || params.publishers!.includes(
+															  || params.publishers?.includes(
 																  pub.slug)
 				)
 			}
 
 			if (params.platforms) {
 				matches = matches && data.platforms.some(plat =>
-															 params.platforms!.includes(
+															 params.platforms?.includes(
 																 String(plat.platform.id))
-															 || params.platforms!.includes(
+															 || params.platforms?.includes(
 																 plat.platform.slug)
 				)
 			}
 
 			if (params.genres) {
 				matches = matches && data.genres.some(gen =>
-														  params.genres!.includes(
+														  params.genres?.includes(
 															  String(gen.id))
-														  || params.genres!.includes(
+														  || params.genres?.includes(
 															  gen.slug)
 				)
 			}
 
 			if (params.tags) {
 				matches = matches && data.tags.some(tag =>
-														params.tags!.includes(
+														params.tags?.includes(
 															String(tag.id))
-														|| params.tags!.includes(
+														|| params.tags?.includes(
 															tag.slug)
 				)
 			}

--- a/src/views/components/PanelHeader/PanelHeader.tsx
+++ b/src/views/components/PanelHeader/PanelHeader.tsx
@@ -24,7 +24,7 @@ export function PanelHeader({ game }: IPanelHeader) {
 			<dl className={style.MetaData}>
 				<dt>game publisher:</dt>
 				<dd className={style.Meta}>
-					{game?.publishers[0]?.name ?? 'NA'}
+					{game.publishers && (game.publishers[0]?.name ?? 'NA')}
 				</dd>
 			</dl>
 


### PR DESCRIPTION
This pull request focuses on improving the handling of optional fields and enhancing the robustness of the code by avoiding potential null or undefined errors. The most important changes include making the `publishers` field optional in the `Game` type, updating the `LocalDbFilter` class to handle optional parameters more gracefully, and modifying the `PanelHeader` component to safely access the `publishers` field.

Changes to optional fields:

* [`src/data/types/Game.ts`](diffhunk://#diff-b61b0b65a6139693a9f186ea297201ea638b546fa05ecd5294bbbed5625d002bL22-R22): Made the `publishers` field optional in the `Game` type.

Enhancements to code robustness:

* [`src/filters/LocalDbFilter.ts`](diffhunk://#diff-b4c748783ffc2ae8a0123da70edfc3e13a1b82de427473644db3adc4805cf542L51-R89): Updated the `LocalDbFilter` class to handle optional parameters using optional chaining (`?.`) and added a check to ensure `data.publishers` is defined before accessing it.
* [`src/views/components/PanelHeader/PanelHeader.tsx`](diffhunk://#diff-bca08d34c4907606c82df1ff02a84d9a8bfa1411b32c19b31c81b167ed051028L27-R27): Modified the `PanelHeader` component to safely access the `publishers` field using a conditional check.